### PR TITLE
Don't remove maxscale binary.

### DIFF
--- a/etc/ubuntu/init.d/maxscale
+++ b/etc/ubuntu/init.d/maxscale
@@ -69,7 +69,6 @@ start() {
 
 stop() {
         log_daemon_msg "Stopping MaxScale"
-        killproc -p $PIDFILE $DAEMON 2>&1 /dev/null
 
         maxscale_wait_stop
 

--- a/etc/ubuntu/init.d/maxscale.in
+++ b/etc/ubuntu/init.d/maxscale.in
@@ -69,7 +69,6 @@ start() {
 
 stop() {
         log_daemon_msg "Stopping MaxScale"
-        killproc -p $PIDFILE $DAEMON 2>&1 /dev/null
 
         maxscale_wait_stop
 


### PR DESCRIPTION
Because of nonexistent $PIDFILE variagle binary was removed when stopping MaxScale.
Delete this line as maxscale will be stopped by maxscale_wait_stop
